### PR TITLE
Change url to official Tabler Icons website

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,4 +257,4 @@ export class ContentComponent implements OnDestroy {
 
 ## Credits
 
-Logo created with [Tabler Icons](https://tablericons.com/).
+Logo created with [Tabler Icons](https://tabler.io/icons/).


### PR DESCRIPTION
Hi Julien, I hope you’re doing well!

I wanted to kindly ask if you could update the link to Tabler Icons to the correct URL: https://tabler.io/icons.

The current site, tablericons.com, isn’t affiliated with the Tabler Icons project. The person behind it is misleading users by claiming to be the author of the library. You can verify the official project and its details here: https://github.com/tabler/tabler-icons.

Thanks so much for your understanding and for supporting accurate representation of the Tabler project!

Pawel - creator of Tabler Icons